### PR TITLE
chore: interfaces-only hack

### DIFF
--- a/src/shacl2code/lang/golang.py
+++ b/src/shacl2code/lang/golang.py
@@ -7,8 +7,22 @@ from .common import BasicJinjaRender
 from .lang import language, TEMPLATE_DIR
 
 import re
-import keyword
 
+DATATYPES = {
+    "http://www.w3.org/2001/XMLSchema#string": "string",
+    "http://www.w3.org/2001/XMLSchema#anyURI": "string",
+    "http://www.w3.org/2001/XMLSchema#integer": "int",
+    "http://www.w3.org/2001/XMLSchema#positiveInteger": "PInt",
+    "http://www.w3.org/2001/XMLSchema#nonNegativeInteger": "uint",
+    "http://www.w3.org/2001/XMLSchema#boolean": "bool",
+    "http://www.w3.org/2001/XMLSchema#decimal": "float64",
+    "http://www.w3.org/2001/XMLSchema#dateTime": "DateTime",
+    "http://www.w3.org/2001/XMLSchema#dateTimeStamp": "DateTimeStamp",
+}
+
+RESERVED_WORDS = {
+    "package"
+}
 
 def export(name):
     # export converts the shacl name into an exportable go type name
@@ -16,6 +30,108 @@ def export(name):
     for i in range(0,len(name_list)):
         name_list[i] = name_list[i][0].upper() + name_list[i][1:]
     return ''.join(name_list)
+
+
+def type_name(name):
+    parts = re.split(r'[^a-zA-Z0-9]', name)
+    part = parts[len(parts)-1]
+    return upper_first(part)
+
+
+def struct_prop_name(prop):
+    # prop:
+    #  class_id, comment, datatype, enum_values, max_count, min_count, path, pattern, varname
+    return lower_first(type_name(prop.varname))
+
+
+def prop_type(prop):
+    # prop:
+    #  class_id, comment, datatype, enum_values, max_count, min_count, path, pattern, varname
+    if prop.datatype in DATATYPES:
+        typ = DATATYPES[prop.datatype]
+    else:
+        typ = type_name(prop.class_id)
+
+    if prop.max_count is None or prop.max_count > 1:
+        typ = '[]' + typ
+
+    return typ
+
+
+def setter_prop_type(prop):
+    typ = prop_type(prop)
+    return typ.replace('[]', "...")
+
+
+def struct_prop(prop):
+    return struct_prop_name(prop) + ' ' + prop_type(prop)
+
+
+def interface_getter(prop):
+    return upper_first(type_name(prop.varname)) + '() ' + prop_type(prop)
+
+
+def interface_setter(prop):
+    return "Set" + upper_first(type_name(prop.varname)) + '(' + setter_prop_type(prop) + ') error'
+
+
+def struct_getter(cls, prop):
+    return 'func (o *' + struct_name(cls) + ') ' + upper_first(type_name(prop.varname)) + '() ' + prop_type(prop) + '{\n' \
+        + '    return o.' + struct_prop_name(prop) + '\n' \
+        + '}'
+
+
+def struct_setter(cls, prop):
+    return 'func (o *' + struct_name(cls) + ') Set' + upper_first(type_name(prop.varname)) + '(v ' + setter_prop_type(prop) + ') error{\n' \
+        + '    o.' + struct_prop_name(prop) + '  = v\n' \
+        + '    return nil\n' \
+        + '}'
+
+
+def comment(indent_with, identifier, text):
+    if text.lower().startswith(identifier.lower()):
+        text = identifier + " " + text[len(identifier):]
+
+    return indent(indent_with, text)
+
+def parent_has_prop(classes, cls, prop):
+    for parent_id in cls.parent_ids:
+        parent = classes.get(parent_id)
+        for p in parent.properties:
+            if p.varname == prop.varname:
+                return True
+        if parent_has_prop(classes, parent, prop):
+            return True
+
+    return False
+
+
+def include_prop(classes, cls, prop):
+    return not parent_has_prop(classes, cls, prop)
+
+
+def lower_first(str):
+    return str[0].lower() + str[1:]
+
+
+def interface_name(cls):
+    return upper_first(type_name(cls.clsname))
+
+
+def struct_name(cls):
+    name = lower_first(type_name(cls.clsname))
+    if name in RESERVED_WORDS:
+        return name + "Impl"
+    return name
+
+
+def upper_first(str):
+    return str[0].upper() + str[1:]
+
+
+def indent(indent_with, str):
+    parts = re.split("\n", str)
+    return indent_with + ("\n"+indent_with).join(parts)
 
 
 @language("golang")
@@ -27,5 +143,16 @@ class GolangRender(BasicJinjaRender):
 
     def get_extra_env(self):
         return {
-                "export": export,
-                }
+            "export": export,
+            "type_name": type_name,
+            "struct_prop": struct_prop,
+            "struct_name": struct_name,
+            "struct_getter": struct_getter,
+            "struct_setter": struct_setter,
+            "interface_name": interface_name,
+            "interface_getter": interface_getter,
+            "interface_setter": interface_setter,
+            "include_prop": include_prop,
+            "indent": indent,
+            "comment": comment,
+        }

--- a/src/shacl2code/lang/templates/golang.j2
+++ b/src/shacl2code/lang/templates/golang.j2
@@ -12,6 +12,57 @@
 {%- endif %}
 {%- endmacro %}
 
+{%- macro struct_props(class) %}
+    {%- for parent in class.parent_ids %}
+    {{ struct_props(classes.get(parent)) }}
+    {%- endfor %}
+
+        // ---------- {{ type_name(class.clsname) }} --------
+    {%- for prop in class.properties %}
+        {%- if include_prop(classes,class,prop) %}
+        {{ struct_prop(prop) }}
+        {%- endif %}
+    {%- endfor %}
+{%- endmacro %}
+
+{%- macro struct_funcs(base,class) %}
+{%- for parent in class.parent_ids %}
+{{ struct_funcs(base,classes.get(parent)) }}
+{%- endfor %}
+
+// ---------- {{ type_name(class.clsname) }} --------
+{%- for prop in class.properties %}
+{%- if include_prop(classes,class,prop) %}
+
+{{ struct_getter(base,prop) }}
+
+{{ struct_setter(base,prop) }}
+{%- endif %}
+{%- endfor %}
+{%- endmacro %}
+
+{%- macro interface_props(class) -%}
+    {%- for parent in class.parent_ids %}
+        {{ interface_name(classes.get(parent)) }}
+    {%- endfor %}
+
+    {%- for prop in class.properties %}
+        {%- if include_prop(classes,class,prop) %}
+
+{{ comment("        // ", struct_prop(prop), prop.comment) }}
+        {{ interface_getter(prop) }}
+
+        {{ interface_setter(prop) }}
+        {%- endif %}
+    {%- endfor %}
+{%- endmacro %}
+
+{%- macro interface_constructor(class) %}
+func New{{ interface_name(class) }}() {{ interface_name(class) }} {
+    return &{{ struct_name(class) }}{}
+}
+{%- endmacro %}
+
 {%- macro datatype(prop) %}
 {%- if prop.class_id -%}
 {{ export(classes.get(prop.class_id).clsname) }}
@@ -20,7 +71,7 @@
 {%- endif %}
 {%- endmacro %}
 
-{% macro interface(class) -%}
+{%- macro interface(class) -%}
 type {{ export(class.clsname) }} interface {
 {%- for prop in class.properties %}
 	{{ export(prop.varname) }}() {{ array(prop) }}{{ datatype(prop) }}
@@ -28,15 +79,14 @@ type {{ export(class.clsname) }} interface {
 }
 {% endmacro %}
 
-{% macro struct(class) -%}
+{%- macro struct(class) -%}
 type {{ export(class.clsname) }} struct {
 {%- for prop in class.properties %}
 }
+{%- endfor %}
 {%- endmacro %}
 
 package spdx_v3_0
-
-import "github.com/orsinium-labs/enum"
 
 // XSD types that don't have a Go equivalent
 type PInt uint
@@ -56,11 +106,12 @@ type DateTimeStamp string
 
 {%- for class in classes %}
 {%- if class.named_individuals %}
-type {{ export(class.clsname) }}Ref enum.Member[string]
+
+type {{ type_name(class.clsname) }} string
 var (
-{% for ind in class.named_individuals %}
-	{{ export(class.clsname) }}{{ export(ind.varname) }} = {{ export(class.clsname) }}Ref{"{{ ind._id }}"}
-{% endfor %}
+{%- for ind in class.named_individuals %}
+    {{ type_name(class.clsname) }}{{ type_name(ind.varname) }} {{ type_name(class.clsname) }} = "{{ ind._id }}"
+{%- endfor %}
 )
 {%- endif %}
 {%- endfor %}
@@ -79,24 +130,33 @@ DATATYPES = {
 }
 %}
 
-var CONTEXT_URLS  [{{ context.urls|length }}]string = [{{ context.urls|length }}]string{
-	{%- for url in context.urls %}"{{ url }}"{{ ',' if not loop.last }}{%- endfor %}}
-
-// CLASSES AND INTERFACES
+{#var CONTEXT_URLS  [{{ context.urls|length }}]string = [{{ context.urls|length }}]string{#}
+{#	{%- for url in context.urls %}"{{ url }}"{{ ',' if not loop.last }}{%- endfor %}}#}
+{##}
+{#// CLASSES AND INTERFACES#}
 
 {%- for class in classes %}
-// {{ export(class.clsname) }} provides the {{ export(class.clsname) }} class in the Model
-type {{ export(class.clsname) }} struct {
-	{%- if class.parent_ids %}
-	{%- for parent in class.parent_ids %}
-	{{ export(classes.get(parent).clsname) }}
-	{%- endfor %}
-	{%- endif %}
-	{%- for prop in class.properties %}
-	{{ export(prop.varname) }} {% if prop.max_count is None or prop.max_count >= 1 %}[]{% endif %}{% if prop.class_id %}{{ export(classes.get(prop.class_id).clsname) }}{% else %}{{ DATATYPES[prop.datatype] }}{% endif %}
-	{%- endfor %}
-	{%- if class.named_individuals %}
-	ObjectRef {{ export(class.clsname) }}Ref
-	{%- endif %}
+{%- if not class.named_individuals %}
+type {{ interface_name(class) }} interface {
+    {{ interface_props(class) }}
 }
+{%- if not class.is_abstract %}
+
+type {{ struct_name(class) }} struct {
+{#-	{%- if class.parent_ids %}#}
+{#-	{%- for parent in class.parent_ids %}#}
+{#-	{{ export(classes.get(parent).clsname) }}#}
+{#-	{%- endfor %}#}
+{#-	{%- endif %}#}
+	{{ struct_props(class) }}
+{#-	{%- if class.named_individuals %}#}
+{#-	ObjectRef {{ export(class.clsname) }}Ref#}
+{#-	{%- endif %}#}
+}
+
+{{ interface_constructor(class) }}
+
+{{ struct_funcs(class,class) }}
+{%- endif %}
+{%- endif %}
 {%- endfor %}

--- a/src/shacl2code/model.py
+++ b/src/shacl2code/model.py
@@ -21,6 +21,7 @@ PATTERN_DATATYPES = [
 class SHACL2CODE(DefinedNamespace):
     idPropertyName: URIRef
     isExtensible: URIRef
+    isAbstract: bool
 
     _NS = Namespace("https://jpewdev.github.io/shacl2code/schema#")
 


### PR DESCRIPTION
This is a quick hack to generate the "interfaces only" approach. A couple notes:

* there is a duplicate property in the model: `publishedTime`, is this a bug?
* the Jinja template seems to only add friction rather than just writing this in plain Python
* writing this in Python is less than ideal because we need to run `go fmt` on the code, which is available in the Go API directly but requires invoking command line here, having the `go` tool available, etc.
* it would be my preference to generate separate files for each of the types